### PR TITLE
Correct `config.exs` example

### DIFF
--- a/_posts/2014-02-15-geting-started-index.md
+++ b/_posts/2014-02-15-geting-started-index.md
@@ -205,7 +205,8 @@ config :sugar,
 
 config :sugar, Router,
   https_only: false,
-  http: [ port: 4000 ]
+  http: [ port: 4000 ],
+  https: false
 ```
 
 This let's the Sugar internals know about your `Router` module and sets the port number on which the HTTP server will listen.


### PR DESCRIPTION
At least in the current implementation, Sugar requires the `:https` configuration key to be either correctly configured (with SSL key/cert and port) or explicitly set to `false`.  This change addresses that and fixes part of Sugar's Issue #61 by providing the necessary instruction for a new user to be able to run `mix server` without strange Cowboy errors.