### PR TITLE
Doc updates

### DIFF
--- a/_posts/2014-02-15-docs-routing.md
+++ b/_posts/2014-02-15-docs-routing.md
@@ -23,7 +23,7 @@ Filters are called before and/or after the controller action is executed, all af
 ## Example
 
 ```elixir
-defmodule Router do
+defmodule YourProject.Router do
   use Sugar.Router
   plug Sugar.Plugs.HotCodeReload
 

--- a/_posts/2014-02-15-geting-started-index.md
+++ b/_posts/2014-02-15-geting-started-index.md
@@ -64,7 +64,7 @@ If you're running Elixir v0.13.2 or higher, [hex](https://hex.pm/) is the prefer
 
 ```elixir
 def deps do
-  [ { :sugar, "~> 0.4.2" } ]
+  [ { :sugar, "~> 0.4.6" } ]
 end
 ```
 
@@ -173,7 +173,7 @@ Enter the router. You define the routes for your web application, and the router
 Let's see what Sugar put in our router.
 
 ```elixir
-defmodule Router do
+defmodule YourProject.Router do
   use Sugar.Router
   plug Sugar.Plugs.HotCodeReload
 
@@ -201,15 +201,15 @@ If you were to try to run your project at this time, it would probably fail. Thi
 
 ```elixir
 config :sugar,
-  router: Router
+  router: YourProject.Router
 
-config :sugar, Router,
+config :sugar, YourProject.Router,
   https_only: false,
   http: [ port: 4000 ],
   https: false
 ```
 
-This let's the Sugar internals know about your `Router` module and sets the port number on which the HTTP server will listen.
+This let's the Sugar internals know about your `YourProject.Router` module and sets the port number on which the HTTP server will listen.
 
 To see the different ways routes can be defined or routers can be configured, checkout the documentation on [routing](/docs/routing/).
 

--- a/_posts/2015-04-03-docs-testing.md
+++ b/_posts/2015-04-03-docs-testing.md
@@ -1,0 +1,50 @@
+---
+layout: docs
+title: Testing
+permalink: /docs/testing/
+---
+
+# Testing
+
+## Controllers
+
+Consider the following controller:
+
+```elixir
+defmodule MyController do
+  use Sugar.Controller
+
+  @doc false
+  def index(conn, []) do
+    # Somehow get our content
+
+    # Render our "mycontroller/index.html.eex" view
+    render conn
+  end
+end
+```
+
+The following can be used to test the above controller:
+
+```elixir
+## This is mostly from the Plug documentation over testing plugs.
+## It's slightly modified for this case.
+defmodule MyControllerTest do
+  use ExUnit.Case, async: true
+  use Plug.Test
+
+  test "returns hello world" do
+    # Create a test connection
+    conn = conn(:get, "/")
+    opts = MyController.init [ action: :index, args: %{} ]
+
+    # Invoke the controller
+    conn = MyController.call(conn, opts)
+
+    # Assert the response and status
+    assert conn.state == :sent
+    assert conn.status == 200
+    assert conn.resp_body == "Hello world"
+  end
+end
+```

--- a/_posts/2015-04-03-docs-views.md
+++ b/_posts/2015-04-03-docs-views.md
@@ -1,0 +1,71 @@
+---
+layout: docs
+title: Views
+permalink: /docs/views/
+---
+
+# Views
+
+Sugar features a number of ways to render views, including both HTML (via EEx) and JSON.
+
+## EEx
+
+Sugar - more specifically, the `Sugar.Controller` module - ships with a `render/4` function that will automatically render a specified EEx template to the specified connection when called.  For example, in your application's main controller:
+
+```elixir
+defmodule YourProject.Controllers.Main do
+  use Sugar.Controller
+  
+  def index do
+    conn |> render(:index)
+  end
+end
+```
+
+The above will cause Sugar to render and send an EEx template located in `lib/your_project/views/main/index.html.eex` (you can configure this in your `config.exs`, however; just set the `:sugar, :views_dir` key to whatever tickles your fancy).  In fact, you don't even need to specify which template to render; as long as you're using standard RESTful template names in the right locations, Sugar will happily guess which template to render based on your controller module's name and the method called, like so:
+
+```elixir
+  def index do
+    # will render `lib/your_project/views/main/index.html.eex`
+    conn |> render
+  end
+```
+
+What if you want to pass some arguments to the template, though?  Well, you can do that, too:
+
+```elixir
+  def show(params) do
+    conn |> render(:show, [foo: find_a_foo(params[:id])])
+  end
+```
+
+## Calliope
+
+`render/4` (as described above) will actually detect and process Haml documents with Calliope if they exist.  Thus, if Haml is more your thing, you can use the same exact code as described above for EEx templates while using Haml templates in `lib/your_project/views/#{your_controller}` and it'll work perfectly!
+
+## Static files
+
+If you have any HTML files that aren't templated in any way, Sugar will gladly find and send them.  Just use the `static/2` function, like so:
+
+```elixir
+  def index do
+    conn |> static("index.html")
+  end
+```
+
+`static/2` looks in the `priv/static` folder of your project's source code.
+
+## JSON
+
+Sugar has built-in support for rendering JSON representations of things using the `json/2` function.  For example:
+
+```elixir
+defmodule YourProject.Controllers.Main do
+  use Sugar.Controller
+  
+  def show_json(params) do
+  # outputs `{foo: "This is foo.", bar: "This is bar."}`
+    conn |> json([foo: "This is foo.", bar: "This is bar."])
+  end
+end
+```


### PR DESCRIPTION
Documentation site now features better namespacing of routers (`YourProject.Router` instead of simply `Router`), a quick bit on testing controllers, and documentation for `render/4`, `static/2`, and `json/2`.