### PR TITLE
Fix controller testing docs

### DIFF
--- a/_posts/2015-04-03-docs-testing.md
+++ b/_posts/2015-04-03-docs-testing.md
@@ -36,10 +36,10 @@ defmodule MyControllerTest do
   test "returns hello world" do
     # Create a test connection
     conn = conn(:get, "/")
-    opts = MyController.init [ action: :index, args: %{} ]
+    opts = MyRouter.init [ action: :index, args: %{} ]
 
-    # Invoke the controller
-    conn = MyController.call(conn, opts)
+    # Invoke the controller via the router
+    conn = MyRouter.call(conn, opts)
 
     # Assert the response and status
     assert conn.state == :sent


### PR DESCRIPTION
The test example was calling router functions on the controller; a test written to emulate the example would not compile.

This new example actually works the controller via the router, so it's not exactly a unit test, but it will have the desired effect. A better example would probably call the controller's :index action directly.